### PR TITLE
Updates

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -247,7 +247,11 @@ onBeforeUnmount(() => {
                 </div>
               </div>
               <div
-                  class="h-[100px] flex items-center justify-between px-10 border-t-2 border-t-white hover:bg-white transition-all duration-300"
+                  @click="() => {
+                    toggleHamburgerMenu();
+                    navigateTo('/');
+                  }"
+                  class="h-[100px] flex items-center justify-between px-10 border-t-2 border-t-white hover:bg-white transition-all duration-300 cursor-pointer"
               >
                 <div>
                   <div class="text-2xl font-semibold text-autonomi-header-text">
@@ -262,7 +266,11 @@ onBeforeUnmount(() => {
                 </div>
               </div>
               <div
-                  class="h-[100px] flex items-center justify-between px-10 border-t-2 border-t-white hover:bg-white transition-all duration-300"
+                  @click="() => {
+                    toggleHamburgerMenu();
+                    navigateTo('/settings');
+                  }"
+                  class="h-[100px] flex items-center justify-between px-10 border-t-2 border-t-white hover:bg-white transition-all duration-300 cursor-pointer"
               >
                 <div>
                   <div class="text-2xl font-semibold text-autonomi-header-text">

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -203,7 +203,13 @@ async function loadSettings() {
   bootstrapPeers.value = app_data.peers.join(',');
 }
 onMounted(async () => {
-  await loadSettings()
+  try {
+    const response = await loadSettings()
+    console.log('>>> Settings response: ', response)
+  }
+  catch (e) {
+    console.log('>>> Error loading settings: ', e)
+  }
 })
 </script>
 

--- a/stores/files.ts
+++ b/stores/files.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { IFolder } from "~/types/folder";
+import type { IFolder, IFile } from "~/types/folder";
 import {useWalletStore} from "~/stores/wallet";
 
 export const useFileStore = defineStore("files", () => {
@@ -62,7 +62,7 @@ export const useFileStore = defineStore("files", () => {
   }
 
   // State
-  const files = ref<any[]>([]);
+  const files = ref<IFile[]>([]);
   const rootDirectory = ref<IFolder | null>(null);
   const currentDirectory = ref<IFolder | null>(null);
   const pendingGetAllFiles = ref(false);
@@ -91,7 +91,7 @@ export const useFileStore = defineStore("files", () => {
 
       files.value.forEach((file) => {
         // TODO: Change Parents to a name that will not be used as a folder name
-        const paths = file.paths.local.split("/");
+        const paths = file.path.split("/");
         let current: any = rootDirectory.value;
 
         paths.forEach((path: string, index: number) => {

--- a/types/folder.ts
+++ b/types/folder.ts
@@ -5,6 +5,28 @@ export interface IFolder {
 }
 
 export interface IFile {
+  file_access: {
+    Private: any[];
+  }
+  metadata: {
+    uploaded: number;
+    created: number;
+    modified: number;
+    size: number;
+  }
+  path: string;
+}
+
+/*
+ DEV Sample of IFile
+{
+  file_access: {Private: BYTES ARRAY}
+  metadata: {uploaded: 1734804991, created: 1734804991, modified: 1734804991, size: 4357964}
+  path: "/ant.log"
+}
+*/
+export interface IFileOLD {
+  // TODO: DELETE THIS IF NOT USED
   paths: {
     local: string;
     network: string;


### PR DESCRIPTION
- added try/catch to catch error when loading settings on mount
  - this issue was throwing errors in the console
- Updated File type
- Updated files to match the return structure Mick outlined
- Attempted to test but still unable to load uploaded files error persists
- Fixed mobile/responsive nav
  - Settings now navigates to the settings page
  - File now navigates home (where file list exists)
  - Wallet (Im not sure where this is supposed to go so left this disabled)