### PR TITLE
fix: avoid connecting multiple clients

### DIFF
--- a/src-tauri/src/ant/client.rs
+++ b/src-tauri/src/ant/client.rs
@@ -9,8 +9,16 @@ pub struct SharedClient {
 
 impl SharedClient {
     pub async fn connect(&self) -> Result<Client, ConnectError> {
+        let mut client_lock = self.client.write().await;
+
+        // check if another thread already connected the client in the meanwhile
+        if let Some(client) = client_lock.as_ref() {
+            return Ok(client.clone());
+        }
+
         let client = Client::init().await?;
-        *self.client.write().await = Some(client.clone());
+        *client_lock = Some(client.clone());
+
         Ok(client)
     }
 
@@ -20,8 +28,8 @@ impl SharedClient {
     }
 
     pub async fn get_client(&self) -> Result<Client, ConnectError> {
-        if let Some(client) = self.client.read().await.clone() {
-            return Ok(client);
+        if let Some(client) = self.client.read().await.as_ref() {
+            return Ok(client.clone());
         }
 
         self.connect().await


### PR DESCRIPTION
Avoids overwriting a newly connected client on calling `SharedClient::connect` in parallel