### PR TITLE
updates

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -159,7 +159,7 @@ onMounted(async () => {
           <div class="flex flex-col justify-start">
             <NuxtLink :class="`${classesLinks}`" to="/">
               <IconFiles class="w-6 h-6" />
-              Home
+              Files
             </NuxtLink>
 
             <NuxtLink :class="`${classesLinks}`" to="/settings">

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -61,10 +61,6 @@ const toggleTokenDropdown = () => {
 };
 
 const toggleHamburgerMenu = () => {
-  if (!wallet.value.isConnected) {
-    return walletStore.showConnectWallet();
-  }
-
   // Hide token dropdown if open
   isTokenDropdownOpen.value = false;
 
@@ -228,6 +224,9 @@ onBeforeUnmount(() => {
             <button
               class="w-10 h-10 bg-autonomi-blue-800 flex items-center justify-center rounded-full cursor-pointer"
               @click="handleClickWallet"
+              v-tooltip.bottom="
+                wallet.isConnected ? 'Disconnect Mobile Wallet' : 'Connect Mobile Wallet'
+              "
             >
               <i class="pi pi-wallet text-white" />
             </button>


### PR DESCRIPTION
- When in mobile view, no hover effect on wallet button (fixed)
- When no wallet connected, clicking mobile view hamburger menu brings up "connect mobile wallet" modal instead of settings menu (fixed)
- Home button in large view is called "Files" in mobile view, let's change large view to say "Files" as well. (fixed)